### PR TITLE
fix: handle GID/UID 1000 conflicts in Ubuntu 24.04

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update \
   && apt-get dist-upgrade -y \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
-  && groupadd -g 1000 webera \
-  && useradd -u 1000 -g webera -s /bin/bash -m webera
+  && (groupadd -g 1000 webera 2>/dev/null || groupadd webera) \
+  && (useradd -u 1000 -g webera -s /bin/bash -m webera 2>/dev/null || useradd -g webera -s /bin/bash -m webera)
 
 # Set security options
 RUN echo "Acquire::http::Pipeline-Depth 0;" > /etc/apt/apt.conf.d/99fixbadproxy \


### PR DESCRIPTION
Ubuntu 24.04 now has a default group with GID 1000, causing the base image build to fail. This fix attempts to create the group/user with specific GID/UID first, then falls back to creating without specific IDs if they're already taken.