### PR TITLE
fix(php): default display_errors to off

### DIFF
--- a/images/php/assets/build.sh
+++ b/images/php/assets/build.sh
@@ -41,7 +41,7 @@ sed -i 's/^;pm.status_path/pm.status_path/' ${php_fpm_www}
 sed -i 's@^;access\.log.*@access.log = /proc/self/fd/1@' ${php_fpm_www}
 sed -i 's@^;clear_env = no@clear_env = no@' ${php_fpm_www}
 echo catch_workers_output = yes >> ${php_fpm_www}
-echo php_flag[display_errors] = on >> ${php_fpm_www}
+echo php_flag[display_errors] = off >> ${php_fpm_www}
 echo php_admin_flag[log_errors] = on >> ${php_fpm_www}
 echo php_admin_value[error_log] = /proc/self/fd/2 >> ${php_fpm_www}
 


### PR DESCRIPTION
## Summary

- Flip `php_flag[display_errors]` from `on` to `off` in the FPM pool config baked into the `webera/php` image.
- `log_errors` stays enabled, so errors still hit stderr / pod logs.

## Why

The pool-level `php_flag[display_errors] = on` overrides the secure default in `php.ini` for every consumer of this image. PHP warnings on `agetechcollaborative.org` were leaking into HTML responses and getting baked into the WP Rocket page cache. See wearewebera/washington#150.

## Blast radius

All images built from `webera/php` will default to `display_errors = off` going forward. Dev environments that want errors rendered can opt in per-deployment with their own pool override or `ini_set` in app code.

## Test plan

- [ ] CI builds and pushes new image
- [ ] Roll washington WordPress deployments to the new tag
- [ ] Confirm `Undefined array key` warnings no longer appear in https://agetechcollaborative.org/testbed/ HTML