### PR TITLE
fix(php): make display_errors unoverridable via php_admin_flag

### DIFF
--- a/images/php/assets/build.sh
+++ b/images/php/assets/build.sh
@@ -41,7 +41,7 @@ sed -i 's/^;pm.status_path/pm.status_path/' ${php_fpm_www}
 sed -i 's@^;access\.log.*@access.log = /proc/self/fd/1@' ${php_fpm_www}
 sed -i 's@^;clear_env = no@clear_env = no@' ${php_fpm_www}
 echo catch_workers_output = yes >> ${php_fpm_www}
-echo php_flag[display_errors] = off >> ${php_fpm_www}
+echo php_admin_flag[display_errors] = off >> ${php_fpm_www}
 echo php_admin_flag[log_errors] = on >> ${php_fpm_www}
 echo php_admin_value[error_log] = /proc/self/fd/2 >> ${php_fpm_www}
 


### PR DESCRIPTION
## Summary

Change the pool override from `php_flag[display_errors] = off` (added in #4) to `php_admin_flag[display_errors] = off`.

`php_flag` is overridable by `ini_set()` at runtime; `php_admin_flag` is not. After #4 landed in production, PHP warnings were *still* reaching HTML output on agetechcollaborative.org — something in WordPress/Elementor flips `display_errors` back on during page rendering, despite no obvious `ini_set` call existing anywhere in `wp-content`. Using the admin flag closes that escape hatch.

See wearewebera/washington#150 for the incident context.

## Test plan

- [ ] CI builds + pushes
- [ ] Re-pin washington WordPress deployments to the new sha
- [ ] `curl https://agetechcollaborative.org/testbed/ | grep -c "Undefined array key"` returns `0`